### PR TITLE
Persisting embeddings in derby db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ build/
 
 ### Mac OS ###
 .DS_Store
+
+
+### DB ###
+vigiliadb/
+derby.log

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,6 +50,11 @@
             <artifactId>derbytools</artifactId>
             <version>${derby.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>${derby.version}</version>
+        </dependency>
 
         <!--SpringDoc dependencies -->
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,6 +16,7 @@
         <springdoc.version>2.6.0</springdoc.version>
         <swagger-ui.version>5.17.14</swagger-ui.version>
         <langchain4j.version>1.0.0-beta1</langchain4j.version>
+        <derby.version>10.17.1.0</derby.version>
     </properties>
 
     <dependencies>
@@ -39,6 +40,17 @@
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring.boot.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derbytools</artifactId>
+            <version>${derby.version}</version>
+        </dependency>
+
         <!--SpringDoc dependencies -->
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/core/src/main/java/org/schlunzis/vigilia/core/api/IndexService.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/api/IndexService.java
@@ -15,15 +15,10 @@ public class IndexService implements IndexApiDelegate {
 
     private final EmbeddingsManager embeddingsManager;
 
-
     @Override
     public ResponseEntity<Void> indexFiles(List<String> paths) {
-
-
-        embeddingsManager.index(paths);
-
-
         log.info("Indexing files: {}", paths);
+        embeddingsManager.index(paths);
         return ResponseEntity.ok().build();
     }
 }

--- a/core/src/main/java/org/schlunzis/vigilia/core/embedding/EmbeddingWrapper.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/embedding/EmbeddingWrapper.java
@@ -4,6 +4,4 @@ import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.data.segment.TextSegment;
 
 public record EmbeddingWrapper(Embedding embedding, TextSegment textSegment) {
-
-
 }

--- a/core/src/main/java/org/schlunzis/vigilia/core/embedding/EmbeddingsManager.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/embedding/EmbeddingsManager.java
@@ -28,13 +28,20 @@ public class EmbeddingsManager {
         List<File> failedFiles = new ArrayList<>();
         List<TextSegment> textSegments = filesReader.readTextSegments(files, failedFiles);
         List<EmbeddingWrapper> embeddings = new ArrayList<>(model.embed(textSegments));
-        embeddingsRepository.saveAll(embeddings.stream().map(EmbeddingEntity::fromEmbeddingWrapper).toList());
+        embeddingsRepository.saveAll(
+                embeddings
+                        .stream()
+                        .map(EmbeddingEntity::fromEmbeddingWrapper)
+                        .toList());
     }
 
     public List<Result> query(String query) {
         log.info("Searching for: {}", query);
 
-        List<EmbeddingWrapper> embeddings = embeddingsRepository.findAll().stream().map(EmbeddingEntity::toEmbeddingWrapper).toList();
+        List<EmbeddingWrapper> embeddings = embeddingsRepository.findAll()
+                .stream()
+                .map(EmbeddingEntity::toEmbeddingWrapper)
+                .toList();
         return model.query(embeddings, query);
     }
 

--- a/core/src/main/java/org/schlunzis/vigilia/core/model/EmbeddingEntity.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/model/EmbeddingEntity.java
@@ -1,0 +1,49 @@
+package org.schlunzis.vigilia.core.model;
+
+import dev.langchain4j.data.document.Metadata;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.schlunzis.vigilia.core.embedding.EmbeddingWrapper;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Since {@link org.schlunzis.vigilia.core.embedding.EmbeddingWrapper} holds fields that are not directly supported by JPA (aka Objects that are not annotated with
+ * {@link jakarta.persistence.Entity}), we need to convert it to a JPA entity.
+ */
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+public class EmbeddingEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @ElementCollection
+    private List<Float> vector;
+
+    private String text;
+
+    @Convert(converter = MetadataConverter.class)
+    private Map<String, Object> metadata;
+
+    public EmbeddingWrapper toEmbeddingWrapper() {
+        Embedding embedding = Embedding.from(vector);
+        TextSegment textSegment = new TextSegment(text, new Metadata(metadata));
+        return new EmbeddingWrapper(embedding, textSegment);
+    }
+
+    public static EmbeddingEntity fromEmbeddingWrapper(EmbeddingWrapper embeddingWrapper) {
+        Embedding embedding = embeddingWrapper.embedding();
+        TextSegment textSegment = embeddingWrapper.textSegment();
+        return new EmbeddingEntity(null, embedding.vectorAsList(), textSegment.text(), textSegment.metadata().toMap());
+    }
+
+
+}

--- a/core/src/main/java/org/schlunzis/vigilia/core/model/EmbeddingsRepository.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/model/EmbeddingsRepository.java
@@ -1,0 +1,11 @@
+package org.schlunzis.vigilia.core.model;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface EmbeddingsRepository extends JpaRepository<EmbeddingEntity, UUID> {
+
+}

--- a/core/src/main/java/org/schlunzis/vigilia/core/model/MetadataConverter.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/model/MetadataConverter.java
@@ -1,0 +1,34 @@
+package org.schlunzis.vigilia.core.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Converter
+public class MetadataConverter implements AttributeConverter<Map<String, Object>, String> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, Object> attribute) {
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error converting map to JSON string.", e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> convertToEntityAttribute(String s) {
+        try {
+            return objectMapper.readValue(s, HashMap.class);
+        } catch (IOException e) {
+            throw new RuntimeException("Error converting JSON string to map.", e);
+        }
+    }
+}

--- a/core/src/main/resources/application.properties
+++ b/core/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 server.port=54913
 server.address=127.0.0.1
+spring.datasource.embedded-database-connection=derby
+spring.jpa.hibernate.ddl-auto=update
+spring.datasource.url=jdbc:derby:vigiliadb;create=true;

--- a/example.md
+++ b/example.md
@@ -1,0 +1,15 @@
+# Cheese
+
+there are many different types of cheese:
+
+- cheddar
+- brie
+- gouda
+- feta
+- blue
+- and many more.
+
+# Dolphins
+
+Dolphins are hunting fish for a healthy diet. They are very intelligent and social animals. They are also known for
+their playful behavior.


### PR DESCRIPTION
## What type of PR is this? (keep all applicable)

- Feature

## Description

Embeddings and Metadata will now be stored in a derby db. Derby was chosen instead of sqlite as it is one of the officially supported embedded databases by spring. However, every start up is accompanied by an exception of features not being implemented. If that results in a restriction for us, we might need to move to another database, potentially sqlite.

Storing the `EmbeddingWrapper` was not as straightforward as expected. Mapping the Wrapper to the Entity could probably be done in a better way, but it works for now. Restructuring the DB Entities might be a good idea when we have a more sophisticated idea of only retrieving parts of the information. But that needs some more thinking. Ideas come to mind of only loading embeddings of special directories. Or only embeddings that are older than a given age.
But for now, we can persist data and the server can restart at any point without loosing the calculated embeddings. 

## Related Tickets & Documents

- Closes #11


