### PR TITLE
28 feature request make query results be pagable

### DIFF
--- a/cli/src/main/java/org/schlunzis/vigilia/cli/CLIApplication.java
+++ b/cli/src/main/java/org/schlunzis/vigilia/cli/CLIApplication.java
@@ -67,7 +67,7 @@ public class CLIApplication {
         if (cmd.hasOption("q")) {
             String[] queryParts = cmd.getOptionValues("q");
             String query = String.join(" ", queryParts);
-            List<SearchResultDTO> resultDTOS = api.searchFiles(query);
+            List<SearchResultDTO> resultDTOS = api.searchFiles(query, null, null);
             for (SearchResultDTO resultDTO : resultDTOS) {
                 log.log(resultDTO);
             }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -115,6 +115,7 @@
                                 <configPackage>org.schlunzis.vigilia.core.config</configPackage>
                                 <useSpringBoot3>true</useSpringBoot3>
                                 <delegatePattern>true</delegatePattern>
+                                <useOptional>true</useOptional>
                             </configOptions>
                         </configuration>
                     </execution>

--- a/core/src/main/java/org/schlunzis/vigilia/core/api/SearchService.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/api/SearchService.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -19,11 +20,15 @@ public class SearchService implements SearchApiDelegate {
     private final EmbeddingsManager embeddingsManager;
 
     @Override
-    public ResponseEntity<List<SearchResultDTO>> searchFiles(String query) {
+    public ResponseEntity<List<SearchResultDTO>> searchFiles(String query, Optional<Integer> pageNumber, Optional<Integer> pageSize) {
         log.info("Searching files: {}", query);
 
-        List<Result> results = embeddingsManager.query(query);
+        long startTime = System.currentTimeMillis();
+        int pn = pageNumber.orElseThrow();
+        int ps = pageSize.orElseThrow();
+        List<Result> results = embeddingsManager.query(query, pn, ps);
 
+        log.info("Search took {} ms", System.currentTimeMillis() - startTime);
         return ResponseEntity.ok(results
                 .stream()
                 .map(r -> new SearchResultDTO()

--- a/core/src/main/java/org/schlunzis/vigilia/core/embedding/EmbeddingsManager.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/embedding/EmbeddingsManager.java
@@ -34,6 +34,7 @@ public class EmbeddingsManager {
                         .stream()
                         .map(EmbeddingEntity::fromEmbeddingWrapper)
                         .toList());
+        queryCache.clear();
     }
 
     public List<Result> query(String query, int pageNumber, int pageSize) {

--- a/core/src/main/java/org/schlunzis/vigilia/core/embedding/EmbeddingsManager.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/embedding/EmbeddingsManager.java
@@ -9,8 +9,7 @@ import org.schlunzis.vigilia.core.model.EmbeddingsRepository;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 @Slf4j
 @Component
@@ -20,6 +19,8 @@ public class EmbeddingsManager {
     private final Model model;
     private final FilesReader filesReader;
     private final EmbeddingsRepository embeddingsRepository;
+
+    Map<String, SortedSet<Result>> queryCache = new HashMap<>();
 
     public void index(List<String> paths) {
         log.info("Indexing paths: {}", paths);
@@ -35,14 +36,21 @@ public class EmbeddingsManager {
                         .toList());
     }
 
-    public List<Result> query(String query) {
+    public List<Result> query(String query, int pageNumber, int pageSize) {
         log.info("Searching for: {}", query);
 
-        List<EmbeddingWrapper> embeddings = embeddingsRepository.findAll()
-                .stream()
-                .map(EmbeddingEntity::toEmbeddingWrapper)
+        SortedSet<Result> results = queryCache.computeIfAbsent(query, _ ->
+                model.query(embeddingsRepository.findAll()
+                                .stream()
+                                .map(EmbeddingEntity::toEmbeddingWrapper)
+                                .toList(),
+                        query)
+        );
+
+        return results.stream()
+                .skip((long) pageNumber * pageSize)
+                .limit(pageSize)
                 .toList();
-        return model.query(embeddings, query);
     }
 
 

--- a/core/src/main/java/org/schlunzis/vigilia/core/embedding/Model.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/embedding/Model.java
@@ -3,19 +3,15 @@ package org.schlunzis.vigilia.core.embedding;
 import dev.langchain4j.data.segment.TextSegment;
 
 import java.util.List;
+import java.util.SortedSet;
 
 public interface Model {
 
 
-    List<Result> query(List<EmbeddingWrapper> embeddingWrappers, String query, int maxResults);
-
-    /**
-     * query with default maxResults = 10
-     */
-    List<Result> query(List<EmbeddingWrapper> embeddingWrappers, String query);
+    SortedSet<Result> query(List<EmbeddingWrapper> embeddingWrappers, String query);
 
     List<EmbeddingWrapper> embed(List<TextSegment> textSegments);
 
-    List<Result> embedAndQuery(List<TextSegment> textSegments, String query);
+    SortedSet<Result> embedAndQuery(List<TextSegment> textSegments, String query);
 
 }

--- a/core/src/main/java/org/schlunzis/vigilia/core/embedding/PrepackagedModel.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/embedding/PrepackagedModel.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.SortedSet;
 import java.util.TreeSet;
 
 @Slf4j
@@ -19,25 +20,18 @@ public class PrepackagedModel implements Model {
     private final EmbeddingModel embeddingModel = new AllMiniLmL6V2EmbeddingModel();
 
     @Override
-    public List<Result> query(List<EmbeddingWrapper> embeddingWrappers, String query, int maxResults) {
+    public SortedSet<Result> query(List<EmbeddingWrapper> embeddingWrappers, String query) {
         log.debug("Embedding query");
         Embedding queryEmbedding = embeddingModel.embed(query).content();
 
         log.debug("Calculating similarity");
 
-        TreeSet<Result> results = new TreeSet<>();
+        SortedSet<Result> results = new TreeSet<>();
         for (EmbeddingWrapper entry : embeddingWrappers) {
             double similarity = CosineSimilarity.between(queryEmbedding, entry.embedding());
             results.add(new Result(similarity, entry.textSegment()));
-            if (results.size() > maxResults)
-                results.pollLast();
         }
-        return List.copyOf(results);
-    }
-
-    @Override
-    public List<Result> query(List<EmbeddingWrapper> embeddingWrappers, String query) {
-        return query(embeddingWrappers, query, 10);
+        return results;
     }
 
     @Override
@@ -52,7 +46,7 @@ public class PrepackagedModel implements Model {
     }
 
     @Override
-    public List<Result> embedAndQuery(List<TextSegment> textSegments, String query) {
+    public SortedSet<Result> embedAndQuery(List<TextSegment> textSegments, String query) {
         return query(embed(textSegments), query);
     }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14,6 +14,7 @@ paths:
       description: Index new files
       operationId: IndexFiles
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -32,7 +33,25 @@ paths:
       summary: Search for files
       description: Search for files
       operationId: SearchFiles
+      parameters:
+        - name: pageNumber
+          in: query
+          description: Page number
+          required: false
+          schema:
+            default: 0
+            type: integer
+            format: int32
+        - name: pageSize
+          in: query
+          description: Page size
+          required: false
+          schema:
+            default: 20
+            type: integer
+            format: int32
       requestBody:
+        required: true
         content:
           text/plain:
             schema:


### PR DESCRIPTION
## What type of PR is this? (keep all applicable)

- Feature

## Description

Queries are now cached and selected pages of content can be returned. This reduces the networkload because in most cases only the first n entries are relevant and not all of them. Also loading further results does not require to recompare all embeddings with the query but the cache is being used. This results in a performance boost of up to 50000%. 

Some drawbacks are, that currently an indexing request results in clearing the cache. This however is not necessary because all newly/reindexed files can easily be removed from the cache and be sorted in again relative to the query.

Also the cache is not emptied at all. There needs to be some kind of schedule or rule that prevents the cache from leaking memory for no reason. A solution can be to clear it in a scheduled time or to only keep the last five or so entries. Also some more sophisticated approaches could be applied to keep track of the queries and suggest queries that have been done multiple times. This however might require some understand of the queries.

## Related Tickets & Documents

- Related Issue(s) #
- Closes #28 


