### PR TITLE
24 server that provides the currently supported files

### DIFF
--- a/core/src/main/java/org/schlunzis/vigilia/core/api/SystemService.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/api/SystemService.java
@@ -1,0 +1,36 @@
+package org.schlunzis.vigilia.core.api;
+
+import lombok.extern.slf4j.Slf4j;
+import org.schlunzis.vigilia.core.io.MediaType;
+import org.schlunzis.vigilia.core.io.SupportedFile;
+import org.schlunzis.vigilia.core.model.SupportedMediaTypesDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.groupingBy;
+
+@Slf4j
+@Service
+public class SystemService implements SystemApiDelegate {
+
+    @Override
+    public ResponseEntity<SupportedMediaTypesDTO> getMediaTypes() {
+
+        Map<MediaType, List<SupportedFile>> groupedSupportedMediaFiles = Arrays.stream(SupportedFile.values()).collect(groupingBy(SupportedFile::getMediaType));
+
+        for (MediaType mediaType : MediaType.values()) {
+            groupedSupportedMediaFiles.computeIfAbsent(mediaType, _ -> List.of());
+        }
+
+        return ResponseEntity.ok(new SupportedMediaTypesDTO()
+                .image(groupedSupportedMediaFiles.get(MediaType.IMAGE).stream().flatMap(sft -> Arrays.stream(sft.getFileExtensions())).toList())
+                .document(groupedSupportedMediaFiles.get(MediaType.DOCUMENT).stream().flatMap(sft -> Arrays.stream(sft.getFileExtensions())).toList())
+                .video(groupedSupportedMediaFiles.get(MediaType.VIDEO).stream().flatMap(sft -> Arrays.stream(sft.getFileExtensions())).toList())
+                .audio(groupedSupportedMediaFiles.get(MediaType.AUDIO).stream().flatMap(sft -> Arrays.stream(sft.getFileExtensions())).toList())
+        );
+    }
+}

--- a/core/src/main/java/org/schlunzis/vigilia/core/io/FilesReader.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/io/FilesReader.java
@@ -66,8 +66,12 @@ public class FilesReader {
     private Optional<List<TextSegment>> readTextSegmentsFromFile(File file) {
         String extension = file.getName().substring(file.getName().lastIndexOf(".") + 1);
         try {
-            switch (extension) {
-                case "md":
+            Optional<SupportedFile> supportedFile = SupportedFile.getSupportedFile(extension);
+            if (supportedFile.isEmpty())
+                return Optional.empty();
+
+            switch (supportedFile.get()) {
+                case MARKDOWN:
                     return Optional.of(new MarkdownSegmenter().readTextSegments(file));
                 default:
                     return Optional.empty();

--- a/core/src/main/java/org/schlunzis/vigilia/core/io/MediaType.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/io/MediaType.java
@@ -1,0 +1,10 @@
+package org.schlunzis.vigilia.core.io;
+
+public enum MediaType {
+
+    DOCUMENT,
+    IMAGE,
+    AUDIO,
+    VIDEO,
+
+}

--- a/core/src/main/java/org/schlunzis/vigilia/core/io/SupportedFile.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/io/SupportedFile.java
@@ -1,0 +1,30 @@
+package org.schlunzis.vigilia.core.io;
+
+import lombok.Getter;
+
+import java.util.Optional;
+
+@Getter
+public enum SupportedFile {
+
+    MARKDOWN(MediaType.DOCUMENT, "md", "markdown");
+
+    private final MediaType mediaType;
+    private final String[] fileExtensions;
+
+    SupportedFile(MediaType mediaType, String... fileExtensions) {
+        this.mediaType = mediaType;
+        this.fileExtensions = fileExtensions;
+    }
+
+    public static Optional<SupportedFile> getSupportedFile(String extension) {
+        for (SupportedFile supportedFile : SupportedFile.values()) {
+            for (String fileExtension : supportedFile.fileExtensions) {
+                if (fileExtension.equals(extension)) {
+                    return Optional.of(supportedFile);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/fx-gui/src/main/java/org/schlunzis/vigilia/gui/fx/service/ApiProvider.java
+++ b/fx-gui/src/main/java/org/schlunzis/vigilia/gui/fx/service/ApiProvider.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 import org.schlunzis.vigilia.gui.fx.api.DefaultApi;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
-final class ApiProvider {
+public final class ApiProvider {
 
     @Getter
     private static final DefaultApi defaultApi;

--- a/fx-gui/src/main/java/org/schlunzis/vigilia/gui/fx/view/TreeFile.java
+++ b/fx-gui/src/main/java/org/schlunzis/vigilia/gui/fx/view/TreeFile.java
@@ -1,11 +1,34 @@
 package org.schlunzis.vigilia.gui.fx.view;
 
+import org.schlunzis.vigilia.gui.fx.ApiException;
+import org.schlunzis.vigilia.gui.fx.api.DefaultApi;
+import org.schlunzis.vigilia.gui.fx.model.SupportedMediaTypesDTO;
+import org.schlunzis.vigilia.gui.fx.service.ApiProvider;
+
 import java.io.File;
+import java.util.List;
 
 public record TreeFile(File file) implements Comparable<TreeFile> {
 
-    // TODO store this at a central place like a common module or request this from the core
-    private static final String[] SUPPORTED_FILE_TYPES = new String[]{".md"};
+    private static final String[] SUPPORTED_FILE_TYPES;
+
+    static {
+        // TODO: This will default to an empty array if the API call fails. This is not ideal.
+        String[] temp;
+        DefaultApi api = ApiProvider.getDefaultApi();
+        try {
+            SupportedMediaTypesDTO supportedMediaTypesDTO = api.getMediaTypes();
+            List<String> supportedFileTypes = supportedMediaTypesDTO.getAudio();
+            supportedFileTypes.addAll(supportedMediaTypesDTO.getVideo());
+            supportedFileTypes.addAll(supportedMediaTypesDTO.getImage());
+            supportedFileTypes.addAll(supportedMediaTypesDTO.getDocument());
+            temp = supportedFileTypes.toArray(new String[0]);
+        } catch (ApiException _) {
+            temp = new String[0];
+        }
+        SUPPORTED_FILE_TYPES = temp;
+    }
+
 
     public String getName() {
         return file.getName();

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -98,6 +98,11 @@ components:
           format: double
     supportedMediaTypes:
       type: object
+      required:
+        - document
+        - image
+        - video
+        - audio
       properties:
         document:
           type: array

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -69,6 +69,20 @@ paths:
           description: Bad request
         '500':
           description: Internal server error
+  /system/media-types:
+    get:
+      summary: Get media types
+      description: Get media types
+      operationId: GetMediaTypes
+      responses:
+        '200':
+          description: Media types retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/supportedMediaTypes'
+        '500':
+          description: Internal server error
 
 components:
   schemas:
@@ -82,3 +96,22 @@ components:
         score:
           type: number
           format: double
+    supportedMediaTypes:
+      type: object
+      properties:
+        document:
+          type: array
+          items:
+            type: string
+        image:
+          type: array
+          items:
+            type: string
+        video:
+          type: array
+          items:
+            type: string
+        audio:
+          type: array
+          items:
+            type: string


### PR DESCRIPTION
## What type of PR is this? (keep all applicable)

- Feature

## Description

A new endpoint has been created which serves the file types that are supported by the core index service. You may still send any file to the server but only supported files will have an appropriate segmenter to process the file. 

## Related Tickets & Documents

- Closes #24 


