### PR TITLE
provide version via api

### DIFF
--- a/core/src/main/java/org/schlunzis/vigilia/core/api/SystemService.java
+++ b/core/src/main/java/org/schlunzis/vigilia/core/api/SystemService.java
@@ -1,8 +1,11 @@
 package org.schlunzis.vigilia.core.api;
 
+import io.swagger.v3.oas.models.OpenAPI;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.schlunzis.vigilia.core.io.MediaType;
 import org.schlunzis.vigilia.core.io.SupportedFile;
+import org.schlunzis.vigilia.core.model.CoreVersionDTO;
 import org.schlunzis.vigilia.core.model.SupportedMediaTypesDTO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -15,7 +18,10 @@ import static java.util.stream.Collectors.groupingBy;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class SystemService implements SystemApiDelegate {
+
+    private final OpenAPI openAPI;
 
     @Override
     public ResponseEntity<SupportedMediaTypesDTO> getMediaTypes() {
@@ -32,5 +38,19 @@ public class SystemService implements SystemApiDelegate {
                 .video(groupedSupportedMediaFiles.get(MediaType.VIDEO).stream().flatMap(sft -> Arrays.stream(sft.getFileExtensions())).toList())
                 .audio(groupedSupportedMediaFiles.get(MediaType.AUDIO).stream().flatMap(sft -> Arrays.stream(sft.getFileExtensions())).toList())
         );
+    }
+
+    @Override
+    public ResponseEntity<CoreVersionDTO> getVersion() {
+        String serviceVersion = getClass().getPackage().getImplementationVersion();
+        if (serviceVersion == null) {
+            serviceVersion = "unknown";
+        }
+        String apiVersion = openAPI.getInfo().getVersion();
+
+        CoreVersionDTO coreVersionDTO = new CoreVersionDTO()
+                .serviceVersion(serviceVersion)
+                .apiVersion(apiVersion);
+        return ResponseEntity.ok(coreVersionDTO);
     }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -83,6 +83,18 @@ paths:
                 $ref: '#/components/schemas/supportedMediaTypes'
         '500':
           description: Internal server error
+  /system/version:
+    get:
+      summary: Get the version of the core
+      description: Get the version of the core
+      operationId: GetVersion
+      responses:
+        '200':
+          description: Version retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CoreVersion'
 
 components:
   schemas:
@@ -120,3 +132,11 @@ components:
           type: array
           items:
             type: string
+    CoreVersion:
+      type: object
+      properties:
+        serviceVersion:
+          type: string
+        apiVersion:
+          type: string
+


### PR DESCRIPTION
## What type of PR is this? (keep all applicable)

- Feature

## Description
The version of the core and the version of the API the core is using is now available via the API.

The CLI part of the implementation has been omitted due to recent developments. You can test this PR by building the core, running the JAR and use the swagger UI to test it.

## Related Tickets & Documents

- Closes #59 


